### PR TITLE
Add docker setup with code-based pairing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
 WORKDIR /app
 COPY . /app
 
-RUN pip install --no-cache-dir bleak openpyxl pexpect
+RUN pip install --no-cache-dir bleak openpyxl pexpect aiohttp
 
 # Verzeichnis für persistente Daten
 VOLUME ["/appdata"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+# Benötigte Pakete für Bluetooth
+RUN apt-get update && \
+    apt-get install -y bluetooth bluez libbluetooth-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . /app
+
+RUN pip install --no-cache-dir bleak openpyxl pexpect
+
+# Verzeichnis für persistente Daten
+VOLUME ["/appdata"]
+ENV DATA_DIR=/appdata
+
+CMD ["python", "main.py"]

--- a/config.py
+++ b/config.py
@@ -1,0 +1,106 @@
+import asyncio
+import json
+import os
+import sys
+
+from bleak import BleakClient, BleakScanner
+
+DATA_DIR = os.getenv("DATA_DIR", "/appdata")
+CONFIG_FILE = os.path.join(DATA_DIR, "config.json")
+
+
+def load_config():
+    if os.path.exists(CONFIG_FILE):
+        with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def save_config(cfg):
+    os.makedirs(DATA_DIR, exist_ok=True)
+    with open(CONFIG_FILE, "w", encoding="utf-8") as f:
+        json.dump(cfg, f)
+
+
+def pair_with_bluetoothctl(address: str) -> bool:
+    """Pairing via ``bluetoothctl`` unter Linux mit PIN-/Passkey-Abfrage."""
+    try:
+        import pexpect
+    except ImportError:
+        print("pexpect nicht installiert")
+        return False
+
+    child = pexpect.spawn("bluetoothctl", encoding="utf-8")
+    try:
+        child.expect("#", timeout=5)
+        child.sendline("agent KeyboardOnly")
+        child.sendline("default-agent")
+        child.sendline(f"pair {address}")
+        while True:
+            idx = child.expect([
+                "Enter PIN code:",
+                r"Confirm passkey .*\[y/N\]",
+                "Pairing successful", "Failed to pair",
+                pexpect.EOF, pexpect.TIMEOUT
+            ], timeout=30)
+            if idx == 0:
+                pin = input("PIN: ")
+                child.sendline(pin)
+            elif idx == 1:
+                child.sendline("yes")
+            elif idx == 2:
+                child.sendline("quit")
+                child.close()
+                return True
+            else:
+                child.sendline("quit")
+                child.close()
+                return False
+    except Exception as e:
+        print(f"bluetoothctl-Fehler: {e}")
+        return False
+
+
+async def pair_device(address: str) -> bool:
+    if sys.platform.startswith("linux"):
+        return await asyncio.to_thread(pair_with_bluetoothctl, address)
+    try:
+        async with BleakClient(address) as client:
+            if not client.is_connected:
+                await client.connect()
+            return await client.pair()
+    except Exception as e:
+        print(f"❌ Pairing-Fehler: {e}")
+        return False
+
+
+async def configure():
+    print("\n🔍 Suche Bluetooth-Geräte...")
+    devices = await BleakScanner.discover(timeout=5.0)
+    if not devices:
+        print("Keine Geräte gefunden")
+        return
+    for idx, d in enumerate(devices, 1):
+        name = d.name or "Unbekannt"
+        print(f"{idx}) {name} [{d.address}]")
+    try:
+        choice = input("Gerät wählen (Nummer) oder Enter abbrechen: ").strip()
+    except EOFError:
+        print()
+        return
+    if choice.isdigit():
+        i = int(choice) - 1
+        if 0 <= i < len(devices):
+            address = devices[i].address
+            print(f"🔗 Versuche Pairing mit {address} ...")
+            if await pair_device(address):
+                cfg = load_config()
+                cfg["device_address"] = address
+                save_config(cfg)
+                print(f"Gerät {address} gespeichert")
+        else:
+            print("Ungültige Auswahl")
+
+
+if __name__ == "__main__":
+    asyncio.run(configure())

--- a/main.py
+++ b/main.py
@@ -233,7 +233,17 @@ async def main():
         print("1) Configuration")
         print("2) Stop Fetching" if running else "2) Start Fetching")
         print("3) Exit")
-        choice = input("> ").strip()
+        try:
+            choice = input("> ").strip()
+        except EOFError:
+            print("\nKeine Eingabe möglich, Programm wird beendet.")
+            if running:
+                fetch_task.cancel()
+                try:
+                    await fetch_task
+                except asyncio.CancelledError:
+                    pass
+            break
 
         if choice == "1":
             await configure(cfg)


### PR DESCRIPTION
## Summary
- set default data directory to `/appdata` so config and logs live in a volume
- create a function using `bluetoothctl` to pair with code on Linux
- call this function from `pair_device` when running on Linux
- make sure Excel and config directories exist before writing
- add Dockerfile with bluetooth dependencies and data volume

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_687555622b10832fb44b0133055a41d5